### PR TITLE
Add /vendor/bundle directory to excludes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,20 +39,17 @@ defaults:
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
-
-# customer excludes
 exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+# customer excludes
   - contribute.md
   - readme.md
-  - vendor/bundle/
 
 # Google Analytics
 google_analytics: UA-158161373-1

--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ defaults:
 exclude:
   - contribute.md
   - readme.md
+  - vendor/bundle/
 
 # Google Analytics
 google_analytics: UA-158161373-1


### PR DESCRIPTION
With all due irony, adding the `excludes` directive to support the
contribute file broke the script the contribute file provided.

The local website runner in `contribute.md` creates a directory
`vendor/bundle` at the top of the repository.  This directory was
ignored until the `exclude` was added to `_config.yml`, apparently
causing the default excludes list (commented out for illustration in
`_config.yml`) to be overwritten instead of augmented.   Jekyll started
to fail serving the local page because of an automatically generated
blog page in that bundle directory.

This patch removes the vendor/bundle directory from the website build
scan.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>