### PR TITLE
Add Change Proposal 7 to resources

### DIFF
--- a/_data/resources/references.yml
+++ b/_data/resources/references.yml
@@ -26,3 +26,7 @@
   desc: Adoption of rdf-toolkit for CASE normalization process
   date: 2020-06-15
   url: CASE Change Proposal 3.zip
+- title: Change Proposal 7
+  desc: Move CASE JSON Examples into own Git Repository
+  date: 2020-07-29
+  url: https://drive.google.com/file/d/1DiLxBTQYt0FQSdjn3mX6RabhqK9QbiDo/view


### PR DESCRIPTION
This implements a new practice - instead of attaching zips to the Git
history, add public Google Drive download links.

Zip SHA-512:
60ba326fb667ec8017e3945f75775ce51dbad5ff9aab5beaa8ffca5035a9f6e4c7f09be7e9c0b6b2c495aea550af4e44350dc247f989cafa44f88d0e7712c65d