### PR TITLE
Add Multiple Browsers narrative to Example Gallery

### DIFF
--- a/ontology/gallery/urls_and_browsing_history/multiple_browsers.html
+++ b/ontology/gallery/urls_and_browsing_history/multiple_browsers.html
@@ -1,0 +1,14 @@
+---
+<!-- layout: blank -->
+title: Multiple Browsers
+jumbo_desc: CASE Sub-topic of URLs and Browsing History
+---
+
+    <div class="row">
+      <div class="col-xs-12">
+        <h2>Introduction</h2>
+        <p>Web browser analysis is an important process in cyber investigations. Some of the key pieces of evidence revealed in browser analysis are history, cache, cookies, downloads list, entered URL addresses, the access time of a visit, and the frequency of visits from the suspect's computer. Digital forensics experts must know how web browsers save data in different operating systems to be able to collect evidence from web browsers with the appropriate tools that may need to examine deleted artifacts. Because each browser stores this information differently, and users can use multiple browsers, it is essential that this information is collectively gathered and presented in a consistent format.</p>
+        <h2>Narrative</h2>
+        <p>A local digital forensics expert is tasked with identifying whether a murder suspect utilized chemical agents to conceal a homicide. First, they identify any internet browsers used by the suspect. Finding that the suspect used multiple, including an uncommon web browser, they request assistance from a Regional Computer Forensics Laboratory (RCFL) and send the lab the uncommon browser’s data directory. In the meantime, their examination of the more common web browsers revealed a querying that was likely used to begin the research, as well as a financial record for the purchase of plastic rain barrels. Unfortunately, this is not enough in itself to tie the suspect to the crime. The local expert waits for the results of the RCFL which analyzed CASE-accompanied data and sent back CASE-wrapped results. The RCFL found deleted artifacts from the unusual browsers that demonstrated the suspect investigated both industrial acids, as well as acid resistant plastics. Additionally, the suspect researched the average volume of a human adult and appropriately sized plastic barrels. Given this information, the forensics expert must now create a chain of events tying the user behavior to the computer over their research timeline.</p>
+      </div>
+    </div>


### PR DESCRIPTION
With the current gallery design, the URLs and Browsing History topic
needs description text to link this narrative.  For the sake of posting
narratives to the website, the narrative is being posted now, and will
be linked when the topic text is written.

This commit ports text drafted by CASE community members.

This patch resolves ONT-218.

References:
* [ONT-218] ONT-189-Narrative-MultipleBrowsers
* [ONT-324] Add "URLs and Browsing History" topic text to gallery page
  to link narratives

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>