### PR TITLE
Add Password-Protected Files narrative to Example Gallery

### DIFF
--- a/ontology/gallery/passwords_tokens_credentials/password_protected_files.html
+++ b/ontology/gallery/passwords_tokens_credentials/password_protected_files.html
@@ -1,0 +1,14 @@
+---
+<!-- layout: blank -->
+title: Password-Protected Files
+jumbo_desc: CASE Sub-topic of Passwords, Tokens, Credentials
+---
+
+    <div class="row">
+      <div class="col-xs-12">
+        <h2>Introduction</h2>
+        <p>Passwords, tokens and credentials are all fundamental elements of authentication. For this reason, the ability to determine these authenticators can be used to tie a specific person to a system's activity, given that they tie together users and capabilities. For this reason, they are often themselves a target of an attack which uses legitimate credentials to commit a crime making it necessary to track their usage in investigating an attack. Additionally, their ubiquity can cause potential reuse which poses both a risk and opportunity for conducting cyber investigations. In these circumstances, password reuse can allow for artifact analysis that can reveal the password itself.</p>
+        <h2>Narrative</h2>
+        <p>An investigator is given a password-protected Windows laptop in a criminal investigation involving online drug trafficking. Initially the investigator uses a password cracker to get the NTLM password hash and convert that to the plain-text equivalent string. However, upon further analysis of the laptop, they find several password-protected files that seem to be related to the crime. The security officer consults CASE artifact sharing information to run a password cracker on the files. Because the password has been reused among its various deployments it recognizable thanks to artifact sharing. The files reveal financial documents and packaging information which confirm the suspects illicit drug activity. Furthermore, the password reuse helps to connect the suspect to the information as well as linking them to further evidence collected.</p>
+      </div>
+    </div>


### PR DESCRIPTION
With the current gallery design, the Passwords, Tokens, Credentials
topic needs description text to link this narrative.  For the sake of
posting narratives to the website, the narrative is being posted now,
and will be linked when the topic text is written.

This commit ports text drafted by CASE community members.

This patch resolves ONT-237.

References:
* [ONT-237] ONT-188-Narrative-PasswordProtectedFiles
* [ONT-330] Add "Passwords, Tokens, Credentials" topic text to gallery
  page to link narratives

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>