### PR TITLE
Add WhatsApp Calls narrative to Example Gallery

### DIFF
--- a/ontology/gallery/call_logs/whatsapp_calls.html
+++ b/ontology/gallery/call_logs/whatsapp_calls.html
@@ -1,0 +1,11 @@
+---
+<!-- layout: blank -->
+title: WhatsApp Calls
+jumbo_desc: CASE Sub-topic of Call Logs
+---
+
+    <div class="row">
+      <div class="col-xs-12">
+        <p>Forensic practitioners investigating a crime are specifically interested in communications within WhatsApp, including the phone calls made using WhatsApp, with associated parties and timestamps.</p>
+      </div>
+    </div>


### PR DESCRIPTION
With the current gallery design, the Call Logs topic needs description
text to link this narrative.  For the sake of posting narratives to the
website, the narrative is being posted now, and will be linked when the
topic text is written.

This commit ports text drafted by CASE community members.

This patch resolves ONT-274.

References:
* [ONT-274] ONT-161-Narrative-WhatsAppCalls
* [ONT-332] Add "Call Logs" topic text to gallery page to link
  narratives

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>