### PR TITLE
Update migration guide for changes from release-0.2.0 branch

### DIFF
--- a/_data/releases/migration_0_2_0/classes.tsv
+++ b/_data/releases/migration_0_2_0/classes.tsv
@@ -37,7 +37,7 @@ OperatingSystem	uco-observable:OperatingSystem
 PathRelation	uco-observable:PathRelation
 PhoneAccount	uco-observable:PhoneAccount
 PhoneCall	uco-observable:PhoneCall
-PropertyBundle	case-core:PropertyBundle
+PropertyBundle	uco-core:Facet
 ProvenanceRecord	uco-investigation:ProvenanceRecord
 RasterPicture	uco-observable:RasterPicture
 SQLiteBlob	uco-observable:SQLiteBlob
@@ -45,6 +45,6 @@ SimpleAddress	uco-location:SimpleAddress
 SimpleName	uco-identity:SimpleName
 Tool	uco-tool:Tool
 ToolConfiguration	uco-tool:ToolConfigurationType
-Trace	case-core:Trace
+Trace	uco-observable:CyberItem
 WiFiAddress	uco-observable:WifiAddress
 iPhoneDevice

--- a/_data/releases/migration_0_2_0/kindOfRelationship_enumerants.tsv
+++ b/_data/releases/migration_0_2_0/kindOfRelationship_enumerants.tsv
@@ -1,6 +1,6 @@
 source_enumerant	destination_enumerant	destination_type
 associated-account
-contained-within	Contained_Within	uco-observable:CyberItemRelationshipEnum
+contained-within	Contained_Within	uco-vocabulary:CyberItemRelationshipVocab
 decoded-from
 decompressed-from
 decrypted-from

--- a/_data/releases/migration_0_2_0/properties.tsv
+++ b/_data/releases/migration_0_2_0/properties.tsv
@@ -91,7 +91,7 @@ pictureheight	uco-observable:pictureHeight
 picturewidth	uco-observable:pictureWidth
 postalCode	uco-location:postalCode
 processorArchitecture	uco-observable:processorArchitecture
-propertyBundle	case-core:hasPropertyBundle
+propertyBundle	uco-core:facets
 protocols	uco-observable:protocols	uco-types:ControlledDictionary
 rangeOffset	uco-observable:rangeOffset
 rangeSize	uco-observable:rangeSize	xsd:long

--- a/releases/0.2.0/migration/index.html
+++ b/releases/0.2.0/migration/index.html
@@ -35,8 +35,8 @@ title: Migration guide
   </thead>
   <tbody>
     <tr>
-      <td><code>case-core</code></td>
-      <td><code>https://caseontology.org/ontology/case/core#</code></td>
+      <td><code>case-investigation</code></td>
+      <td><code>https://caseontology.org/ontology/case/investigation#</code></td>
     </tr>
     <tr>
       <td><code>uco-action</code></td>
@@ -49,10 +49,6 @@ title: Migration guide
     <tr>
       <td><code>uco-identity</code></td>
       <td><code>https://unifiedcyberontology.org/ontology/uco/identity#</code></td>
-    </tr>
-    <tr>
-      <td><code>uco-investigation</code></td>
-      <td><code>https://unifiedcyberontology.org/ontology/uco/investigation#</code></td>
     </tr>
     <tr>
       <td><code>uco-location</code></td>
@@ -73,6 +69,10 @@ title: Migration guide
     <tr>
       <td><code>uco-tool</code></td>
       <td><code>https://unifiedcyberontology.org/ontology/uco/tool#</code></td>
+    </tr>
+    <tr>
+      <td><code>uco-vocabulary</code></td>
+      <td><code>https://unifiedcyberontology.org/ontology/uco/vocabulary#</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
References:
* [ONT-231] (CP-10) Definition of Trace from CASE prototype not
  preserved
* [ONT-281] (CP-9) Adoption of Investigation namespace from UCO into
  CASE
* [ONT-353] Review migration guide against release-0.2.0 branch
* [UCO Issue 75] Refactor how vocabularies are defined
  https://github.com/ucoProject/UCO/issues/75
* [UCO Issue 143] Casing correction - "picturetype"
  https://github.com/ucoProject/UCO/issues/143

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>