### PR TITLE
Update website release links for 0.2.0

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -3,12 +3,12 @@
 - name: Releases
   submenuitems:
     - name: Latest Release
-      link: /releases/0.1.0/
+      link: /releases/0.2.0/
     - name: Archived Releases
       link: /releases/archive/
     - name: SPACE
     - name: Under Development
-      link: /releases/0.2.0/
+      link: /releases/0.3.0/
 
 - name: Ontology
   submenuitems:

--- a/_data/releases/releases.yml
+++ b/_data/releases/releases.yml
@@ -1,3 +1,6 @@
 - title: 0.1.0
   date: 2017-01-13
   desc: Initial (“prototype”) release of the CASE ontology. Included concepts copied from UCO rather than imported.
+- title: 0.2.0
+  date: 2020-08-20
+  desc: Release of the CASE ontology with an encoded relationship with UCO. Removed prototype file, imported UCO, and provided investigation namespace.

--- a/releases/0.3.0/index.md
+++ b/releases/0.3.0/index.md
@@ -1,0 +1,19 @@
+---
+title: 0.3.0 Release
+layout: releases
+custom_css: releases
+---
+
+## {{ page.title }}
+
+###### Date: _TBD_
+
+#### Ontology File(s)
+
+[GitHub](https://github.com/casework/CASE/tree/develop)
+
+#### Migration guidance
+
+A guide to migration from CASE 0.2.0 will be provided.
+
+#### Release Notes


### PR DESCRIPTION
I confirmed the navigation bar, the archive page, and the new, empty
0.3.0 page are navigable and render as one would expect.

References:
* [ONT-359] Update website release links for 0.2.0

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>