### PR TITLE
Add Github Action for Continuous Integration checks

### DIFF
--- a/.github/workflows/web_resources.yml
+++ b/.github/workflows/web_resources.yml
@@ -1,0 +1,41 @@
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+# This workflow uses Make to confirm Git-tracked website pages match the contents generated from affiliated source files.
+
+name: Web resources CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Clear generated files
+      run: make clean
+    - name: Regenerate files
+      run: make
+    - name: Check regenerated files
+      run: make check


### PR DESCRIPTION
This workflow executes steps I have been using to confirm data-driven
files, built for serving on Github's Jekyll service, are synchronized
with their source files.  Actual instructions to run tests in each
directory were encoded in Makefiles prior to this patch.

This patch addresses part of ONT-360: Establishing the CI framework.
A follow-on patch will add narrative page building, somewhat abstracted,
to the Make build chain.

Please note this disclaimer related to mention of specific software:
Participation by NIST in the creation of the instructions for this
software is not intended to imply a recommendation or endorsement by the
National Institute of Standards and Technology, nor is it intended to
imply that any specific software is necessarily the best available for
the purpose.

References:
* [ONT-360] The website repository needs Continuous Integration for MVP
  development

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>