### PR TITLE
Implement and test query for photographs of exhibits

### DIFF
--- a/examples/urgent_evidence/Makefile
+++ b/examples/urgent_evidence/Makefile
@@ -27,6 +27,8 @@ check: \
 	test ! -s index.html.diff \
 	  || (echo "ERROR:examples/urgent_evidence/Makefile:The file index.html is out of sync with its source files, index.html.in, urgent_evidence.json, and/or the .sparql files.  Please regenerate index.html by running 'make' and committing the update." >&2 ; exit 1)
 	rm *.diff
+	source $(top_srcdir)/venv/bin/activate \
+	  && pytest
 
 clean:
 	@rm -f *.diff
@@ -35,6 +37,7 @@ clean:
 index.html: \
   index.html.in \
   urgent_evidence-query-action_timeline.html \
+  urgent_evidence-query-exhibit_photos.html \
   urgent_evidence-query-investigative_locations.html \
   urgent_evidence-query-investigative_personae.html
 	cp \
@@ -73,6 +76,18 @@ index.html: \
 	sed \
 	  -e '/@QUERY_INVESTIGATIVE_PERSONAE_HTML@/r urgent_evidence-query-investigative_personae.html' \
 	  -e '/@QUERY_INVESTIGATIVE_PERSONAE_HTML@/d' \
+	  _$@ \
+	  > __$@
+	mv __$@ _$@
+	sed \
+	  -e '/@QUERY_EXHIBIT_PHOTOS_SPARQL@/r urgent_evidence-query-exhibit_photos.sparql' \
+	  -e '/@QUERY_EXHIBIT_PHOTOS_SPARQL@/d' \
+	  _$@ \
+	  > __$@
+	mv __$@ _$@
+	sed \
+	  -e '/@QUERY_EXHIBIT_PHOTOS_HTML@/r urgent_evidence-query-exhibit_photos.html' \
+	  -e '/@QUERY_EXHIBIT_PHOTOS_HTML@/d' \
 	  _$@ \
 	  > __$@
 	mv __$@ _$@

--- a/examples/urgent_evidence/index.html
+++ b/examples/urgent_evidence/index.html
@@ -354,5 +354,191 @@ ORDER BY ?lLastName
           </div>
         </div>
 
+        <div class="card">
+          <h5 class="card-header">Photographs of exhibits</h5>
+          <div class="card-body">
+            <p class="card-text">What photographs were taken of the exhibit and sub-exhibits? (<a href="urgent_evidence-query-exhibit_photos.sparql">SPARQL source</a>)</p>
+{% highlight sparql %}
+SELECT ?lExhibitNumber ?lFileName ?lModifiedTime ?lHashValue
+WHERE {
+
+  # This query uses sub-queries to prevent unnecessary joins.
+  # The first sub-query identifies for which graph nodes we will retrieve
+  # annotating properties.
+
+  # The files being returned are photographs that were created as the
+  # results of investigative actions, and are recorded in the generated
+  # provenance records.
+  # Retrieve the exhibit devices' nodes and the file objects' nodes.
+
+  {
+    SELECT ?nExhibitDevice ?nPictureFile
+    WHERE {
+      ?nPictureFile
+        a uco-observable:CyberItem ;
+        uco-core:facets ?nRasterPictureFacet ;
+        .
+
+      ?nInvestigativeAction
+        a case-investigation:InvestigativeAction ;
+        uco-core:facets ?nActionReferencesFacet ;
+        .
+
+      ?nActionReferencesFacet
+        a uco-action:ActionReferences ;
+        uco-action:instrument kb:camera-uuid-1 ;
+        uco-action:object ?nExhibitDevice ;
+        uco-action:result ?nPictureFile ;
+        uco-action:result ?nProvenanceRecord ;
+        .
+
+      kb:camera-uuid-1
+        a uco-tool:AnalyticTool ;
+        .
+
+      # The provenance record confirms the picture file was recorded in
+      # the provenance chain.
+
+      ?nProvenanceRecord
+        a case-investigation:ProvenanceRecord ;
+        uco-core:object ?nPictureFile ;
+        .
+
+      # The raster picture facet distinguishes these files as picture
+      # files.
+
+      ?nRasterPictureFacet
+        a uco-observable:RasterPicture ;
+        .
+
+      # Because provenance records are input to some actions, confirm
+      # that the exhibit device node has a Device facet, to prevent
+      # accidentally returning provenance records in this inner query's
+      # results.
+      # (These two blocks retrieving the facet can cause a Cartesian
+      # product if not run in a sub-, or at this point sub-sub-, query.)
+
+      {
+        SELECT ?nExhibitDevice
+        WHERE {
+          ?nExhibitDevice
+            a uco-observable:CyberItem ;
+            uco-core:facets ?nDeviceFacet ;
+            .
+
+          ?nDeviceFacet
+            a uco-observable:Device ;
+            .
+        }
+      }  # Ends sub-query: SELECT ?nExhibitDevice
+    }
+  }  # Ends sub-query: SELECT ?nExhibitDevice ?nPictureFile
+
+  # The first returned property for the outer query is the label of the
+  # subject device, which must be retrieved by one of the provenance
+  # records that is not a result of taking the pictures.
+  # This is run in a SELECT DISTINCT sub-query because multiple
+  # provenance records of the subject device attach the exhibit number
+  # redundantly.
+  {
+    SELECT DISTINCT ?nExhibitDevice ?lExhibitNumber
+    WHERE {
+      ?nLabellingProvenanceRecord
+        a case-investigation:ProvenanceRecord ;
+        case-investigation:exhibitNumber ?lExhibitNumber ;
+        uco-core:object ?nExhibitDevice ;
+        .
+    }
+  }
+
+  # The other properties being returned are characteristics of the
+  # files.  Retrieve those properties once the sub-query has returned
+  # which files.
+
+  ?nPictureFile
+    uco-core:facets ?nContentDataFacet ;
+    uco-core:facets ?nFileFacet ;
+    .
+
+  ?nContentDataFacet
+    a uco-observable:ContentData ;
+    uco-observable:hash ?nHash ;
+    .
+
+  ?nHash
+    uco-types:hashValue ?lHashValue ;
+    .
+
+  ?nFileFacet
+    a uco-observable:File ;
+    uco-observable:fileName ?lFileName ;
+    uco-observable:modifiedTime ?lModifiedTime ;
+    .
+
+}
+ORDER BY ?lExhibitNumber ?lFileName
+{% endhighlight %}
+<table border="1" class="dataframe table table-bordered table-condensed">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>?lExhibitNumber</th>
+      <th>?lFileName</th>
+      <th>?lModifiedTime</th>
+      <th>?lHashValue</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>EXH-20190101-7</td>
+      <td>IMG_4829.jpg</td>
+      <td>2019-01-01T14:14:07+00:00</td>
+      <td>6ba5b138057cca4e737a86083cf28426093f218efbef64967863a6c83138fe89</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>EXH-20190101-7</td>
+      <td>IMG_4830.jpg</td>
+      <td>2019-01-01T14:14:30+00:00</td>
+      <td>cadc54f42a9d01ecb5ecdc3a9a4824c73301d6ce9857eaa73fc28317ccd5d40f</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>EXH-20190101-7</td>
+      <td>IMG_4831.jpg</td>
+      <td>2019-01-01T14:15:00+00:00</td>
+      <td>ee3657ad73c09098312e71a31ca7ac468c1fb1b998b5d6647ad471dcc89c4141</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>EXH-20190101-7</td>
+      <td>IMG_4832.jpg</td>
+      <td>2019-01-01T14:20:07+00:00</td>
+      <td>132bfadcc46addedcafcd84653f1a56007eba2f27bfcb15824536cda65a49c9a</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>EXH-20190101-7</td>
+      <td>IMG_4833.jpg</td>
+      <td>2019-01-01T14:20:32+00:00</td>
+      <td>1929ec6c6186f43860da7c77c0c65d1b8543a5543572261a1b71084e7bf80a0e</td>
+    </tr>
+    <tr>
+      <th>5</th>
+      <td>EXH-20190101-7</td>
+      <td>IMG_4834.jpg</td>
+      <td>2019-01-01T14:21:00+00:00</td>
+      <td>fc0819ed4dcb2af9c85a041a0da11ea6a146dec0b108c09f5e0d41e8ea3bb041</td>
+    </tr>
+  </tbody>
+</table>
+            <p class="card-text">Of note:</p>
+            <ul>
+              <li class="card-text">This query hard-codes knowledge of the device used to photograph the evidence, <code>kb:camera-uuid-1</code>, to avoid confusing pictures taken of evidence with pictures extracted from evidence.  A change to UCO is under consideration to enable this query to function based on a tool class, without needing to hard code the camera's identifier.</li>
+            </ul>
+          </div>
+        </div>
+
       </div>
     </div>

--- a/examples/urgent_evidence/index.html.in
+++ b/examples/urgent_evidence/index.html.in
@@ -136,5 +136,21 @@ jumbo_desc: CASE Sub-topic of Chain of Custody
           </div>
         </div>
 
+        <div class="card">
+          <h5 class="card-header">Photographs of exhibits</h5>
+          <div class="card-body">
+            <p class="card-text">What photographs were taken of the exhibit and sub-exhibits? (<a href="urgent_evidence-query-exhibit_photos.sparql">SPARQL source</a>)</p>
+{% highlight sparql %}
+@QUERY_EXHIBIT_PHOTOS_SPARQL@
+{% endhighlight %}
+@QUERY_EXHIBIT_PHOTOS_HTML@
+
+            <p class="card-text">Of note:</p>
+            <ul>
+              <li class="card-text">This query hard-codes knowledge of the device used to photograph the evidence, <code>kb:camera-uuid-1</code>, to avoid confusing pictures taken of evidence with pictures extracted from evidence.  A change to UCO is under consideration to enable this query to function based on a tool class, without needing to hard code the camera's identifier.</li>
+            </ul>
+          </div>
+        </div>
+
       </div>
     </div>

--- a/examples/urgent_evidence/test_urgent_evidence.py
+++ b/examples/urgent_evidence/test_urgent_evidence.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+
+import rdflib.plugins.sparql
+
+_logger = logging.getLogger(os.path.basename(__file__))
+
+graph = rdflib.Graph()
+graph.parse("urgent_evidence.json", format="json-ld")
+
+# Inherit prefixes defined in input context dictionary.
+nsdict = {k:v for (k,v) in graph.namespace_manager.namespaces()}
+
+def test_exhibit_photos():
+    file_names_computed = set()
+    file_names_ground_truth_positive = {
+      "IMG_4829.jpg",
+      "IMG_4830.jpg",
+      "IMG_4831.jpg",
+      "IMG_4832.jpg",
+      "IMG_4833.jpg",
+      "IMG_4834.jpg"
+    }
+    file_names_ground_truth_negative = {
+      "IMG_1863.jpg"
+    }
+
+    select_query_text = None
+    with open("urgent_evidence-query-exhibit_photos.sparql", "r") as in_fh:
+        select_query_text = in_fh.read().strip()
+    _logger.debug("select_query_text = %r." % select_query_text)
+    select_query_object = rdflib.plugins.sparql.prepareQuery(select_query_text, initNs=nsdict)
+    for record in graph.query(select_query_object):
+        (
+          l_exhibit_number,
+          l_file_name,
+          l_modified_time,
+          l_hash_value,
+        ) = record
+        file_names_computed.add(l_file_name.toPython())
+
+    file_names_true_positive = file_names_computed & file_names_ground_truth_positive
+    assert file_names_ground_truth_positive == file_names_true_positive
+
+    file_names_false_positive = file_names_computed & file_names_ground_truth_negative
+    assert set() == file_names_false_positive

--- a/examples/urgent_evidence/urgent_evidence-query-exhibit_photos.sparql
+++ b/examples/urgent_evidence/urgent_evidence-query-exhibit_photos.sparql
@@ -1,0 +1,118 @@
+SELECT ?lExhibitNumber ?lFileName ?lModifiedTime ?lHashValue
+WHERE {
+
+  # This query uses sub-queries to prevent unnecessary joins.
+  # The first sub-query identifies for which graph nodes we will retrieve
+  # annotating properties.
+
+  # The files being returned are photographs that were created as the
+  # results of investigative actions, and are recorded in the generated
+  # provenance records.
+  # Retrieve the exhibit devices' nodes and the file objects' nodes.
+
+  {
+    SELECT ?nExhibitDevice ?nPictureFile
+    WHERE {
+      ?nPictureFile
+        a uco-observable:CyberItem ;
+        uco-core:facets ?nRasterPictureFacet ;
+        .
+
+      ?nInvestigativeAction
+        a case-investigation:InvestigativeAction ;
+        uco-core:facets ?nActionReferencesFacet ;
+        .
+
+      ?nActionReferencesFacet
+        a uco-action:ActionReferences ;
+        uco-action:instrument kb:camera-uuid-1 ;
+        uco-action:object ?nExhibitDevice ;
+        uco-action:result ?nPictureFile ;
+        uco-action:result ?nProvenanceRecord ;
+        .
+
+      kb:camera-uuid-1
+        a uco-tool:AnalyticTool ;
+        .
+
+      # The provenance record confirms the picture file was recorded in
+      # the provenance chain.
+
+      ?nProvenanceRecord
+        a case-investigation:ProvenanceRecord ;
+        uco-core:object ?nPictureFile ;
+        .
+
+      # The raster picture facet distinguishes these files as picture
+      # files.
+
+      ?nRasterPictureFacet
+        a uco-observable:RasterPicture ;
+        .
+
+      # Because provenance records are input to some actions, confirm
+      # that the exhibit device node has a Device facet, to prevent
+      # accidentally returning provenance records in this inner query's
+      # results.
+      # (These two blocks retrieving the facet can cause a Cartesian
+      # product if not run in a sub-, or at this point sub-sub-, query.)
+
+      {
+        SELECT ?nExhibitDevice
+        WHERE {
+          ?nExhibitDevice
+            a uco-observable:CyberItem ;
+            uco-core:facets ?nDeviceFacet ;
+            .
+
+          ?nDeviceFacet
+            a uco-observable:Device ;
+            .
+        }
+      }  # Ends sub-query: SELECT ?nExhibitDevice
+    }
+  }  # Ends sub-query: SELECT ?nExhibitDevice ?nPictureFile
+
+  # The first returned property for the outer query is the label of the
+  # subject device, which must be retrieved by one of the provenance
+  # records that is not a result of taking the pictures.
+  # This is run in a SELECT DISTINCT sub-query because multiple
+  # provenance records of the subject device attach the exhibit number
+  # redundantly.
+  {
+    SELECT DISTINCT ?nExhibitDevice ?lExhibitNumber
+    WHERE {
+      ?nLabellingProvenanceRecord
+        a case-investigation:ProvenanceRecord ;
+        case-investigation:exhibitNumber ?lExhibitNumber ;
+        uco-core:object ?nExhibitDevice ;
+        .
+    }
+  }
+
+  # The other properties being returned are characteristics of the
+  # files.  Retrieve those properties once the sub-query has returned
+  # which files.
+
+  ?nPictureFile
+    uco-core:facets ?nContentDataFacet ;
+    uco-core:facets ?nFileFacet ;
+    .
+
+  ?nContentDataFacet
+    a uco-observable:ContentData ;
+    uco-observable:hash ?nHash ;
+    .
+
+  ?nHash
+    uco-types:hashValue ?lHashValue ;
+    .
+
+  ?nFileFacet
+    a uco-observable:File ;
+    uco-observable:fileName ?lFileName ;
+    uco-observable:modifiedTime ?lModifiedTime ;
+    .
+
+}
+ORDER BY ?lExhibitNumber ?lFileName

--- a/examples/urgent_evidence/urgent_evidence.json
+++ b/examples/urgent_evidence/urgent_evidence.json
@@ -8,6 +8,7 @@
         "uco-identity": "https://unifiedcyberontology.org/ontology/uco/identity#",
         "uco-location": "https://unifiedcyberontology.org/ontology/uco/location#",
         "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
+        "uco-tool": "https://unifiedcyberontology.org/ontology/uco/tool#",
         "uco-types": "https://unifiedcyberontology.org/ontology/uco/types#"
     },
     "@graph": [
@@ -117,6 +118,9 @@
                     "@type": "xsd:dateTime",
                     "@value": "2019-01-01T14:15+00:00"
                 },
+                "uco-action:instrument": {
+                    "@id": "kb:camera-uuid-1"
+                },
                 "uco-action:location": {
                     "@id": "kb:location-uuid-3"
                 },
@@ -175,6 +179,9 @@
                 "uco-action:endTime": {
                     "@type": "xsd:dateTime",
                     "@value": "2019-01-01T14:21+00:00"
+                },
+                "uco-action:instrument": {
+                    "@id": "kb:camera-uuid-1"
                 },
                 "uco-action:location": {
                     "@id": "kb:location-uuid-3"
@@ -241,6 +248,9 @@
                 "uco-action:result": [
                     {
                         "@id": "kb:provenance-record-uuid-6"
+                    },
+                    {
+                        "@id": "kb:extracted-file-uuid-1"
                     },
                     {
                         "@id": "kb:file-uuid-2"
@@ -538,6 +548,26 @@
             "uco-core:description": "Sealed Exhibit handed the OIC & Transfer documentation signed"
         },
         {
+            "@id": "kb:camera-uuid-1",
+            "@type": [
+                "uco-observable:CyberItem",
+                "uco-tool:AnalyticTool"
+            ],
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:Device",
+                    "uco-observable:manufacturer": "Canon",
+                    "uco-observable:model": "PowerShot SX540"
+                }
+            ],
+            "uco-tool:creator": "Canon"
+        },
+        {
+            "@id": "kb:kiosk-uuid-1",
+            "@type": "uco-tool:AnalyticTool",
+            "uco-tool:creator": "ACME"
+        },
+        {
             "@id": "kb:location-uuid-1",
             "@type": "uco-location:Location",
             "uco-core:description": "(Room 1-001) Police station intake lab",
@@ -677,9 +707,14 @@
             "@id": "kb:provenance-record-uuid-6",
             "@type": "case-investigation:ProvenanceRecord",
             "case-investigation:exhibitNumber": "EXH-20190101-7-KioskReport",
-            "uco-core:object": {
-                "@id": "kb:file-uuid-2"
-            }
+            "uco-core:object": [
+                {
+                    "@id": "kb:extracted-file-uuid-1"
+                },
+                {
+                    "@id": "kb:file-uuid-2"
+                }
+            ]
         },
         {
             "@id": "kb:provenance-record-uuid-7",
@@ -702,6 +737,598 @@
             "uco-core:object": {
                 "@id": "kb:subject-device-uuid-1"
             }
+        },
+        {
+            "@id": "kb:subject-device-photograph-uuid-1",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:ContentData",
+                    "uco-observable:mimeType": "image/jpeg",
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 4929041
+                    },
+                    "uco-observable:hash": [
+                        {
+                            "@type": "uco-types:Hash",
+                            "uco-types:hashMethod": {
+                                "@type": "uco-vocabulary:HashNameVocab",
+                                "@value": "SHA256"
+                            },
+                            "uco-types:hashValue": {
+                                "@type": "xsd:hexBinary",
+                                "@value": "6ba5b138057cca4e737a86083cf28426093f218efbef64967863a6c83138fe89"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "@type": "uco-observable:EXIF",
+                    "uco-observable:exifData": {
+                        "@type": "uco-types:ControlledDictionary",
+                            "uco-types:entry": [
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "DateTimeDigitized",
+                                "uco-types:value": "2019-01-01 14:14:07"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Height",
+                                "uco-types:value": "4000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Width",
+                                "uco-types:value": "6000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Make",
+                                "uco-types:value": "Canon"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Model",
+                                "uco-types:value": "PowerShot SX540"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Orientation",
+                                "uco-types:value": "Horizontal (normal)"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@type": "uco-observable:File",
+                    "uco-observable:extension": "jpg",
+                    "uco-observable:fileName": "IMG_4829.jpg",
+                    "uco-observable:modifiedTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2019-01-01T14:14:07+00:00"
+                    },
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 4929041
+                    }
+                },
+                {
+                    "@type": "uco-observable:RasterPicture",
+                    "uco-observable:pictureType": "jpg",
+                    "uco-observable:pictureHeight": 6000,
+                    "uco-observable:pictureWidth": 4000
+                }
+            ]
+        },
+        {
+            "@id": "kb:subject-device-photograph-uuid-2",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:ContentData",
+                    "uco-observable:mimeType": "image/jpeg",
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 4491816
+                    },
+                    "uco-observable:hash": [
+                        {
+                            "@type": "uco-types:Hash",
+                            "uco-types:hashMethod": {
+                                "@type": "uco-vocabulary:HashNameVocab",
+                                "@value": "SHA256"
+                            },
+                            "uco-types:hashValue": {
+                                "@type": "xsd:hexBinary",
+                                "@value": "cadc54f42a9d01ecb5ecdc3a9a4824c73301d6ce9857eaa73fc28317ccd5d40f"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "@type": "uco-observable:EXIF",
+                    "uco-observable:exifData": {
+                        "@type": "uco-types:ControlledDictionary",
+                            "uco-types:entry": [
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "DateTimeDigitized",
+                                "uco-types:value": "2019-01-01 14:14:30"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Height",
+                                "uco-types:value": "4000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Width",
+                                "uco-types:value": "6000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Make",
+                                "uco-types:value": "Canon"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Model",
+                                "uco-types:value": "PowerShot SX540"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Orientation",
+                                "uco-types:value": "Horizontal (normal)"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@type": "uco-observable:File",
+                    "uco-observable:extension": "jpg",
+                    "uco-observable:fileName": "IMG_4830.jpg",
+                    "uco-observable:modifiedTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2019-01-01T14:14:30+00:00"
+                    },
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 4491816
+                    }
+                },
+                {
+                    "@type": "uco-observable:RasterPicture",
+                    "uco-observable:pictureType": "jpg",
+                    "uco-observable:pictureHeight": 6000,
+                    "uco-observable:pictureWidth": 4000
+                }
+            ]
+        },
+        {
+            "@id": "kb:subject-device-photograph-uuid-3",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:ContentData",
+                    "uco-observable:mimeType": "image/jpeg",
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 3236101
+                    },
+                    "uco-observable:hash": [
+                        {
+                            "@type": "uco-types:Hash",
+                            "uco-types:hashMethod": {
+                                "@type": "uco-vocabulary:HashNameVocab",
+                                "@value": "SHA256"
+                            },
+                            "uco-types:hashValue": {
+                                "@type": "xsd:hexBinary",
+                                "@value": "ee3657ad73c09098312e71a31ca7ac468c1fb1b998b5d6647ad471dcc89c4141"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "@type": "uco-observable:EXIF",
+                    "uco-observable:exifData": {
+                        "@type": "uco-types:ControlledDictionary",
+                            "uco-types:entry": [
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "DateTimeDigitized",
+                                "uco-types:value": "2019-01-01 14:15:00"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Height",
+                                "uco-types:value": "4000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Width",
+                                "uco-types:value": "6000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Make",
+                                "uco-types:value": "Canon"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Model",
+                                "uco-types:value": "PowerShot SX540"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Orientation",
+                                "uco-types:value": "Horizontal (normal)"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@type": "uco-observable:File",
+                    "uco-observable:extension": "jpg",
+                    "uco-observable:fileName": "IMG_4831.jpg",
+                    "uco-observable:modifiedTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2019-01-01T14:15:00+00:00"
+                    },
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 3236101
+                    }
+                },
+                {
+                    "@type": "uco-observable:RasterPicture",
+                    "uco-observable:pictureType": "jpg",
+                    "uco-observable:pictureHeight": 6000,
+                    "uco-observable:pictureWidth": 4000
+                }
+            ]
+        },
+        {
+            "@id": "kb:subject-device-photograph-uuid-4",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:ContentData",
+                    "uco-observable:mimeType": "image/jpeg",
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 3777924
+                    },
+                    "uco-observable:hash": [
+                        {
+                            "@type": "uco-types:Hash",
+                            "uco-types:hashMethod": {
+                                "@type": "uco-vocabulary:HashNameVocab",
+                                "@value": "SHA256"
+                            },
+                            "uco-types:hashValue": {
+                                "@type": "xsd:hexBinary",
+                                "@value": "132bfadcc46addedcafcd84653f1a56007eba2f27bfcb15824536cda65a49c9a"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "@type": "uco-observable:EXIF",
+                    "uco-observable:exifData": {
+                        "@type": "uco-types:ControlledDictionary",
+                            "uco-types:entry": [
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "DateTimeDigitized",
+                                "uco-types:value": "2019-01-01 14:20:07"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Height",
+                                "uco-types:value": "4000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Width",
+                                "uco-types:value": "6000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Make",
+                                "uco-types:value": "Canon"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Model",
+                                "uco-types:value": "PowerShot SX540"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Orientation",
+                                "uco-types:value": "Horizontal (normal)"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@type": "uco-observable:File",
+                    "uco-observable:extension": "jpg",
+                    "uco-observable:fileName": "IMG_4832.jpg",
+                    "uco-observable:modifiedTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2019-01-01T14:20:07+00:00"
+                    },
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 3777924
+                    }
+                },
+                {
+                    "@type": "uco-observable:RasterPicture",
+                    "uco-observable:pictureType": "jpg",
+                    "uco-observable:pictureHeight": 6000,
+                    "uco-observable:pictureWidth": 4000
+                }
+            ]
+        },
+        {
+            "@id": "kb:subject-device-photograph-uuid-5",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:ContentData",
+                    "uco-observable:mimeType": "image/jpeg",
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 5010291
+                    },
+                    "uco-observable:hash": [
+                        {
+                            "@type": "uco-types:Hash",
+                            "uco-types:hashMethod": {
+                                "@type": "uco-vocabulary:HashNameVocab",
+                                "@value": "SHA256"
+                            },
+                            "uco-types:hashValue": {
+                                "@type": "xsd:hexBinary",
+                                "@value": "1929ec6c6186f43860da7c77c0c65d1b8543a5543572261a1b71084e7bf80a0e"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "@type": "uco-observable:EXIF",
+                    "uco-observable:exifData": {
+                        "@type": "uco-types:ControlledDictionary",
+                            "uco-types:entry": [
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "DateTimeDigitized",
+                                "uco-types:value": "2019-01-01 14:20:32"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Height",
+                                "uco-types:value": "4000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Width",
+                                "uco-types:value": "6000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Make",
+                                "uco-types:value": "Canon"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Model",
+                                "uco-types:value": "PowerShot SX540"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Orientation",
+                                "uco-types:value": "Horizontal (normal)"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@type": "uco-observable:File",
+                    "uco-observable:extension": "jpg",
+                    "uco-observable:fileName": "IMG_4833.jpg",
+                    "uco-observable:modifiedTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2019-01-01T14:20:32+00:00"
+                    },
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 5010291
+                    }
+                },
+                {
+                    "@type": "uco-observable:RasterPicture",
+                    "uco-observable:pictureType": "jpg",
+                    "uco-observable:pictureHeight": 6000,
+                    "uco-observable:pictureWidth": 4000
+                }
+            ]
+        },
+        {
+            "@id": "kb:subject-device-photograph-uuid-6",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:ContentData",
+                    "uco-observable:mimeType": "image/jpeg",
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 4565505
+                    },
+                    "uco-observable:hash": [
+                        {
+                            "@type": "uco-types:Hash",
+                            "uco-types:hashMethod": {
+                                "@type": "uco-vocabulary:HashNameVocab",
+                                "@value": "SHA256"
+                            },
+                            "uco-types:hashValue": {
+                                "@type": "xsd:hexBinary",
+                                "@value": "fc0819ed4dcb2af9c85a041a0da11ea6a146dec0b108c09f5e0d41e8ea3bb041"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "@type": "uco-observable:EXIF",
+                    "uco-observable:exifData": {
+                        "@type": "uco-types:ControlledDictionary",
+                            "uco-types:entry": [
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "DateTimeDigitized",
+                                "uco-types:value": "2019-01-01 14:21:00"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Height",
+                                "uco-types:value": "4000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Width",
+                                "uco-types:value": "6000"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Make",
+                                "uco-types:value": "Canon"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Model",
+                                "uco-types:value": "PowerShot SX540"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Orientation",
+                                "uco-types:value": "Horizontal (normal)"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@type": "uco-observable:File",
+                    "uco-observable:extension": "jpg",
+                    "uco-observable:fileName": "IMG_4834.jpg",
+                    "uco-observable:modifiedTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2019-01-01T14:21:00+00:00"
+                    },
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 4565505
+                    }
+                },
+                {
+                    "@type": "uco-observable:RasterPicture",
+                    "uco-observable:pictureType": "jpg",
+                    "uco-observable:pictureHeight": 6000,
+                    "uco-observable:pictureWidth": 4000
+                }
+            ]
+        },
+        {
+            "@id": "kb:extracted-file-uuid-1",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:ContentData",
+                    "uco-observable:mimeType": "image/jpeg",
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 2964571
+                    },
+                    "uco-observable:hash": [
+                        {
+                            "@type": "uco-types:Hash",
+                            "uco-types:hashMethod": {
+                                "@type": "uco-vocabulary:HashNameVocab",
+                                "@value": "SHA256"
+                            },
+                            "uco-types:hashValue": {
+                                "@type": "xsd:hexBinary",
+                                "@value": "a49f0716e610bd0f77543b1e7ca7613e9b31bf32509e854c7ba65b79be502a18"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "@type": "uco-observable:EXIF",
+                    "uco-observable:exifData": {
+                        "@type": "uco-types:ControlledDictionary",
+                            "uco-types:entry": [
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "DateTimeDigitized",
+                                "uco-types:value": "2018-12-15 12:11:54"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Height",
+                                "uco-types:value": "2448"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Image Width",
+                                "uco-types:value": "3264"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Make",
+                                "uco-types:value": "Apple"
+                            },
+                            {
+                                "@type": "uco-types:ControlledDictionaryEntry",
+                                "uco-types:key": "Model",
+                                "uco-types:value": "iPhone 4S"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@type": "uco-observable:File",
+                    "uco-observable:extension": "jpg",
+                    "uco-observable:fileName": "IMG_1863.jpg",
+                    "uco-observable:modifiedTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2018-12-15T12:11:54+00:00"
+                    },
+                    "uco-observable:sizeInBytes": {
+                        "@type": "xsd:long",
+                        "@value": 2964571
+                    }
+                },
+                {
+                    "@type": "uco-observable:RasterPicture",
+                    "uco-observable:pictureType": "jpg",
+                    "uco-observable:pictureHeight": 3264,
+                    "uco-observable:pictureWidth": 2448
+                }
+            ]
+        },
+        {
+            "@id": "kb:subject-device-uuid-1",
+            "@type": "uco-observable:CyberItem",
+            "uco-core:facets": [
+                {
+                    "@type": "uco-observable:Device"
+                }
+            ]
         }
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 SPARQLWrapper
 pandas
+pytest
 rdflib-jsonld
 requests


### PR DESCRIPTION
This patch adds the following:
* A rudimentary definition of the subject device.  Intentionally, no
  descriptors are provided save it has a Device facet.
* Definitions of two analytic tools already noted in the narrative, the
  camera and the analytic kiosk.
* Definitions of the six photograph files taken of the device.
* Definition of a single photograph file extracted from the device as
  part of the kiosk analysis.  This is to supply ground truth negative,
  a potentially-confused file, for a query for photographs of the
  evidence.
* A test for picture files for photographs of the device, excluding a
  picture file extracted from the device.

This patch adds a new dependency on pytest to the top virtual
environment, to test the query results.

This patch will potentially require a follow-on patch after resolution
of the addition of Camera class to UCO's Tool namespace.  This matter is
likely to be settled by CASE 0.3.0 or CASE 0.4.0.

References:
* [ONT-367] Query - photographs of exhibits (Urgent Evidence, Narrative ONT-118)
* [UCO OC-75] (CP-22) Add Camera class to Tool namespace

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>