### PR TITLE
Assign prefix for XML Schema

### DIFF
--- a/examples/urgent_evidence/index.html
+++ b/examples/urgent_evidence/index.html
@@ -134,73 +134,73 @@ ORDER BY ?lEndTime
     <tr>
       <th>0</th>
       <td></td>
-      <td>2019-01-01T14:00+00:00</td>
+      <td>2019-01-01 14:00:00+00:00</td>
       <td>Exhibit submitted for Kiosk examination</td>
     </tr>
     <tr>
       <th>1</th>
       <td></td>
-      <td>2019-01-01T14:05+00:00</td>
+      <td>2019-01-01 14:05:00+00:00</td>
       <td>Exhibit seal checks (passed) &amp; Exhibit receipted in lab</td>
     </tr>
     <tr>
       <th>2</th>
       <td></td>
-      <td>2019-01-01T14:05:30+00:00</td>
+      <td>2019-01-01 14:05:30+00:00</td>
       <td>Exhibit assigned to Kiosk technician</td>
     </tr>
     <tr>
       <th>3</th>
       <td></td>
-      <td>2019-01-01T14:15+00:00</td>
+      <td>2019-01-01 14:15:00+00:00</td>
       <td>Sealed Exhibit Photographed</td>
     </tr>
     <tr>
       <th>4</th>
       <td></td>
-      <td>2019-01-01T14:20+00:00</td>
+      <td>2019-01-01 14:20:00+00:00</td>
       <td>Exhibit Unsealed</td>
     </tr>
     <tr>
       <th>5</th>
       <td></td>
-      <td>2019-01-01T14:21+00:00</td>
+      <td>2019-01-01 14:21:00+00:00</td>
       <td>Unsealed Exhibit Photographed</td>
     </tr>
     <tr>
       <th>6</th>
-      <td>2019-01-01T14:25+00:00</td>
-      <td>2019-01-01T14:55+00:00</td>
+      <td>2019-01-01 14:25:00+00:00</td>
+      <td>2019-01-01 14:55:00+00:00</td>
       <td>Exhibit Connected to Kiosk &amp; process started; exhibit disconnected at conclusion</td>
     </tr>
     <tr>
       <th>7</th>
       <td></td>
-      <td>2019-01-01T15:00+00:00</td>
+      <td>2019-01-01 15:00:00+00:00</td>
       <td>Exhibit Resealed</td>
     </tr>
     <tr>
       <th>8</th>
       <td></td>
-      <td>2019-01-01T15:05+00:00</td>
+      <td>2019-01-01 15:05:00+00:00</td>
       <td>Report DVD Generated as associated exhibit</td>
     </tr>
     <tr>
       <th>9</th>
       <td></td>
-      <td>2019-01-01T15:10+00:00</td>
+      <td>2019-01-01 15:10:00+00:00</td>
       <td>DVD Report sealed</td>
     </tr>
     <tr>
       <th>10</th>
       <td></td>
-      <td>2019-01-01T15:15+00:00</td>
+      <td>2019-01-01 15:15:00+00:00</td>
       <td>Witness statement completed</td>
     </tr>
     <tr>
       <th>11</th>
       <td></td>
-      <td>2019-01-01T15:20+00:00</td>
+      <td>2019-01-01 15:20:00+00:00</td>
       <td>Sealed Exhibit handed the OIC &amp; Transfer documentation signed</td>
     </tr>
   </tbody>
@@ -502,42 +502,42 @@ ORDER BY ?lExhibitNumber ?lFileName
       <th>0</th>
       <td>EXH-20190101-7</td>
       <td>IMG_4829.jpg</td>
-      <td>2019-01-01T14:14:07+00:00</td>
+      <td>2019-01-01 14:14:07+00:00</td>
       <td>6ba5b138057cca4e737a86083cf28426093f218efbef64967863a6c83138fe89</td>
     </tr>
     <tr>
       <th>1</th>
       <td>EXH-20190101-7</td>
       <td>IMG_4830.jpg</td>
-      <td>2019-01-01T14:14:30+00:00</td>
+      <td>2019-01-01 14:14:30+00:00</td>
       <td>cadc54f42a9d01ecb5ecdc3a9a4824c73301d6ce9857eaa73fc28317ccd5d40f</td>
     </tr>
     <tr>
       <th>2</th>
       <td>EXH-20190101-7</td>
       <td>IMG_4831.jpg</td>
-      <td>2019-01-01T14:15:00+00:00</td>
+      <td>2019-01-01 14:15:00+00:00</td>
       <td>ee3657ad73c09098312e71a31ca7ac468c1fb1b998b5d6647ad471dcc89c4141</td>
     </tr>
     <tr>
       <th>3</th>
       <td>EXH-20190101-7</td>
       <td>IMG_4832.jpg</td>
-      <td>2019-01-01T14:20:07+00:00</td>
+      <td>2019-01-01 14:20:07+00:00</td>
       <td>132bfadcc46addedcafcd84653f1a56007eba2f27bfcb15824536cda65a49c9a</td>
     </tr>
     <tr>
       <th>4</th>
       <td>EXH-20190101-7</td>
       <td>IMG_4833.jpg</td>
-      <td>2019-01-01T14:20:32+00:00</td>
+      <td>2019-01-01 14:20:32+00:00</td>
       <td>1929ec6c6186f43860da7c77c0c65d1b8543a5543572261a1b71084e7bf80a0e</td>
     </tr>
     <tr>
       <th>5</th>
       <td>EXH-20190101-7</td>
       <td>IMG_4834.jpg</td>
-      <td>2019-01-01T14:21:00+00:00</td>
+      <td>2019-01-01 14:21:00+00:00</td>
       <td>fc0819ed4dcb2af9c85a041a0da11ea6a146dec0b108c09f5e0d41e8ea3bb041</td>
     </tr>
   </tbody>

--- a/examples/urgent_evidence/urgent_evidence.json
+++ b/examples/urgent_evidence/urgent_evidence.json
@@ -9,7 +9,8 @@
         "uco-location": "https://unifiedcyberontology.org/ontology/uco/location#",
         "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
         "uco-tool": "https://unifiedcyberontology.org/ontology/uco/tool#",
-        "uco-types": "https://unifiedcyberontology.org/ontology/uco/types#"
+        "uco-types": "https://unifiedcyberontology.org/ontology/uco/types#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/src/sample_sparql_runner.py
+++ b/src/sample_sparql_runner.py
@@ -35,7 +35,7 @@ import logging
 import pandas as pd
 import rdflib.plugins.sparql
 
-NS_XSD_HEXBINARY = rdflib.XSD.hexBinary
+NS_XSD = rdflib.XSD
 
 _logger = logging.getLogger(os.path.basename(__file__))
 
@@ -65,7 +65,7 @@ def main():
         for (column_no, column) in enumerate(row):
             if column is None:
                 column_value = ""
-            elif isinstance(column, rdflib.term.Literal) and column.datatype == NS_XSD_HEXBINARY:
+            elif isinstance(column, rdflib.term.Literal) and column.datatype == NS_XSD.hexBinary:
                 # Use hexlify to convert xsd:hexBinary to ASCII.
                 # The render to ASCII is in support of this script rendering results for website viewing.
                 # .decode() is because hexlify returns bytes.


### PR DESCRIPTION
The XML Schema datatypes prefix is "xs:" in some RDF frameworks, "xsd:"
in others.  If not specified, a framework may assume the default-looking
prefix it doesn't use is an arbitrary string.

References:
* [AC-154] XML Schema datatype prefix needs to be explicit in all
  examples

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>