### PR TITLE
Add demonstration ontologies for website-based retrieval

### DIFF
--- a/ontology/testing_versioned_iris_case/case
+++ b/ontology/testing_versioned_iris_case/case
@@ -1,0 +1,32 @@
+# baseURI: https://caseontology.org/ontology/case/case
+# imports: https://caseontology.org/ontology/case/investigation
+# imports: https://caseontology.org/ontology/case/vocabulary
+# imports: https://unifiedcyberontology.org/ontology/uco/uco
+
+@base <https://caseontology.org/ontology/testing_versioned_iris_case/case> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://caseontology.org/ontology/testing_versioned_iris_case/case>
+	a owl:Ontology ;
+	rdfs:label "case-master"@en ;
+	rdfs:comment "NOTE: This is a test demonstration of publishing ontology files with versioned IRIs, and should not be used for production data.  This URL will be removed on test conclusion."@en ;
+	dct:title "TEST Cyber-investigation Analysis Standard Expression (CASE)"@en ;
+	owl:imports
+		<http://dev.caseontology.org/ontology/case/investigation/0.2.1> ,
+		<http://dev.caseontology.org/ontology/case/vocabulary/0.2.1> ,
+		<http://dev.caseontology.org/ontology/uco/uco/0.4.1>
+		;
+	owl:incompatibleWith <http://case.example.org/core> ;
+	owl:ontologyIRI <https://caseontology.org/ontology/testing_versioned_iris_case/case> ;
+	owl:priorVersion <http://case.example.org/core> ;
+	owl:versionIRI <http://dev.caseontology.org/ontology/case/case/0.2.1> ;
+	owl:versionInfo "0.2.1" ;
+	.
+

--- a/ontology/testing_versioned_iris_case/investigation
+++ b/ontology/testing_versioned_iris_case/investigation
@@ -1,0 +1,215 @@
+# baseURI: http://dev.caseontology.org/ontology/case/investigation/0.2.1
+# imports: http://dev.caseontology.org/ontology/case/vocabulary/0.2.1
+# imports: http://dev.caseontology.org/ontology/uco/action/0.4.1
+# imports: http://dev.caseontology.org/ontology/uco/core/0.4.1
+# imports: http://dev.caseontology.org/ontology/uco/location/0.4.1
+# imports: http://dev.caseontology.org/ontology/uco/role/0.4.1
+
+@base <https://caseontology.org/ontology/testing_versioned_iris_case/investigation> .
+@prefix investigation: <http://dev.caseontology.org/ontology/case/investigation/0.2.1#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix uco-action: <http://dev.caseontology.org/ontology/uco/action/0.4.1#> .
+@prefix uco-core: <http://dev.caseontology.org/ontology/uco/core/0.4.1#> .
+@prefix uco-role: <http://dev.caseontology.org/ontology/uco/role/0.4.1#> .
+@prefix vocabulary: <http://dev.caseontology.org/ontology/case/vocabulary/0.2.1#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://caseontology.org/ontology/testing_versioned_iris_case/investigation>
+	a owl:Ontology ;
+	rdfs:label "investigation"@en ;
+	rdfs:comment "NOTE: This is a test demonstration of publishing ontology files with versioned IRIs, and should not be used for production data.  This URL will be removed on test conclusion."@en ;
+	owl:imports
+		<http://dev.caseontology.org/ontology/case/vocabulary/0.2.1> ,
+		<http://dev.caseontology.org/ontology/uco/action/0.4.1> ,
+		<http://dev.caseontology.org/ontology/uco/core/0.4.1> ,
+		<http://dev.caseontology.org/ontology/uco/location/0.4.1> ,
+		<http://dev.caseontology.org/ontology/uco/role/0.4.1>
+		;
+	owl:ontologyIRI <https://caseontology.org/ontology/testing_versioned_iris_case/investigation> ;
+	owl:versionIRI <http://dev.caseontology.org/ontology/case/investigation/0.2.1> ;
+	owl:versionInfo "0.2.1" ;
+	.
+
+investigation:Attorney
+	a owl:Class ;
+	rdfs:subClassOf uco-role:BenevolentRole ;
+	rdfs:label "Attorney"@en ;
+	rdfs:comment ""@en ;
+	.
+
+investigation:Authorization
+	a owl:Class ;
+	rdfs:subClassOf
+		uco-core:UcoObject ,
+		[
+			a owl:Restriction ;
+			owl:onProperty investigation:authorizationType ;
+			owl:cardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty uco-core:endTime ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:dateTime ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty uco-core:startTime ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:dateTime ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty investigation:authorizationIdentifier ;
+			owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		]
+		;
+	rdfs:label "Authorization"@en ;
+	rdfs:comment "Identifies some form of authorization for investigatory action."@en ;
+	.
+
+investigation:Examiner
+	a owl:Class ;
+	rdfs:subClassOf uco-role:BenevolentRole ;
+	rdfs:label "Examiner"@en ;
+	rdfs:comment ""@en ;
+	.
+
+investigation:ExaminerActionLifecylce
+	a owl:Class ;
+	rdfs:subClassOf uco-action:ActionLifecycle ;
+	rdfs:label "ExaminerActionLifecylce"@en ;
+	rdfs:comment ""@en ;
+	.
+
+investigation:Investigation
+	a owl:Class ;
+	rdfs:subClassOf
+		uco-core:ContextualCompilation ,
+		[
+			a owl:Restriction ;
+			owl:onProperty investigation:investigationForm ;
+			owl:cardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty investigation:investigationStatus ;
+			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty uco-core:endTime ;
+			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty uco-core:startTime ;
+			owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+		]
+		;
+	rdfs:label "Investigation"@en ;
+	rdfs:comment "An exploration of the facts involved in a cyber-relevant set of suspicious activity."@en ;
+	.
+
+investigation:InvestigativeAction
+	a owl:Class ;
+	rdfs:subClassOf uco-action:Action ;
+	rdfs:label "InvestigativeAction"@en ;
+	rdfs:comment "An examination action taken as part of a cyber investigation."@en ;
+	.
+
+investigation:Investigator
+	a owl:Class ;
+	rdfs:subClassOf uco-role:BenevolentRole ;
+	rdfs:label "Investigator"@en ;
+	rdfs:comment ""@en ;
+	.
+
+investigation:ProvenanceRecord
+	a owl:Class ;
+	rdfs:subClassOf
+		uco-core:ContextualCompilation ,
+		[
+			a owl:Restriction ;
+			owl:onProperty investigation:exhibitNumber ;
+			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
+		]
+		;
+	rdfs:label "ProvenanceRecord"@en ;
+	rdfs:comment "A provenantial connection between a forensic action and a set of observations (items and/or actions) or interpretations that result from it."@en ;
+	.
+
+investigation:Subject
+	a owl:Class ;
+	rdfs:subClassOf uco-role:MaliciousRole ;
+	rdfs:label "Subject"@en ;
+	rdfs:comment ""@en ;
+	.
+
+investigation:SubjectActionLifecycle
+	a owl:Class ;
+	rdfs:subClassOf uco-action:ActionLifecycle ;
+	rdfs:label "SubjectActionLifecycle"@en ;
+	rdfs:comment ""@en ;
+	.
+
+investigation:VictimActionLifecycle
+	a owl:Class ;
+	rdfs:subClassOf uco-action:ActionLifecycle ;
+	rdfs:label "VictimActionLifecycle"@en ;
+	rdfs:comment ""@en ;
+	.
+
+investigation:authorizationIdentifier
+	a owl:DatatypeProperty ;
+	rdfs:label "authorizationIdentifier"@en ;
+	rdfs:comment "The identifier for a particular authorization (e.g. warrant number)"@en ;
+	rdfs:range xsd:string ;
+	.
+
+investigation:authorizationType
+	a owl:DatatypeProperty ;
+	rdfs:label "authorizationType"@en ;
+	rdfs:comment "A label categorizing a type of authorization (e.g. warrant)"@en ;
+	rdfs:range xsd:string ;
+	.
+
+investigation:exhibitNumber
+	a owl:DatatypeProperty ;
+	rdfs:label "exhibitNumber"@en ;
+	rdfs:comment ""@en ;
+	rdfs:range xsd:string ;
+	.
+
+investigation:focus
+	a owl:DatatypeProperty ;
+	rdfs:label "focus"@en ;
+	rdfs:comment "Specifies the topical focus of an investigation."@en ;
+	rdfs:range xsd:string ;
+	.
+
+investigation:investigationForm
+	a owl:DatatypeProperty ;
+	rdfs:label "investigationForm"@en ;
+	rdfs:comment "A label categorizing a type of investigation (case, incident, suspicious-activity, etc.)"@en ;
+	rdfs:range vocabulary:InvestigationFormVocab ;
+	.
+
+investigation:investigationStatus
+	a owl:DatatypeProperty ;
+	rdfs:label "investigationStatus"@en ;
+	rdfs:comment "A label characterizing the status of an investigation (open, closed, etc.)."@en ;
+	rdfs:range xsd:string ;
+	.
+
+investigation:relevantAuthorization
+	a owl:ObjectProperty ;
+	rdfs:label "relevantAuthorization"@en ;
+	rdfs:comment "Specifies an authorization relevant to a particular investigation."@en ;
+	rdfs:range investigation:Authorization ;
+	.
+


### PR DESCRIPTION
These files are temporary, and are expected to be retracted after
completion of ONT-64.

References:
* [ONT-64] (CP-17) Define scheme for CASE and UCO importable versioned
  IRIs
* [ONT-412] (CP-26) Implement versionIRI in CASE 0.2.0

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>