### PR TITLE
Expand topics table's IRI column width to prevent line breaks

### DIFF
--- a/assets/css/topics.css
+++ b/assets/css/topics.css
@@ -1,0 +1,8 @@
+table.table-condensed ul {
+  padding-left: 1em;
+}
+
+/* Keep long prefixed IRIs from wrapping. */
+table.table-condensed li code {
+  white-space: nowrap;
+}

--- a/examples/topics.html
+++ b/examples/topics.html
@@ -2,6 +2,7 @@
 <!-- layout: releases -->
 title: Topics
 jumbo_desc: Investigative topic support in CASE
+custom_css: topics
 ---
 
     <p>The <a href="/examples/">CASE narrative examples gallery</a> illustrates snippets of CASE data that would appear in cyber investigations, using narratives to provide a cohesive demonstration.  The concepts used in those illustrations can be grouped into various topics of investigative relevance.</p>


### PR DESCRIPTION
The current breaking for investigative action is:

    case-
    investigation:Investi
    gativeAction

This CSS adjustment removes padding and sets the minimum column width to
be content-controlled, based on longest prefixed IRI.

Visually tested with Firefox in Ubuntu, and Firefox, Chrome, and Safari
in macOS.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>