### PR TITLE
Correct kindOfRelationship literal references

### DIFF
--- a/examples/asgard/asgard.json
+++ b/examples/asgard/asgard.json
@@ -314,7 +314,7 @@
                 }
             ],
             "uco-core:kindOfRelationship": {
-                "@type": "uco-observable:ObservableObjectRelationshipEnum",
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "Contained_Within"
             },
             "uco-core:isDirectional": true,

--- a/examples/asgard/asgard_3.json
+++ b/examples/asgard/asgard_3.json
@@ -52,7 +52,7 @@
             }
         ],
         "uco-core:kindOfRelationship": {
-            "@type": "uco-observable:ObservableObjectRelationshipEnum",
+            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
             "@value": "Contained_Within"
         },
         "uco-core:isDirectional": true,

--- a/examples/asgard/index.html
+++ b/examples/asgard/index.html
@@ -390,7 +390,7 @@ custom_js:
             }
         ],
         "uco-core:kindOfRelationship": {
-            "@type": "uco-observable:ObservableObjectRelationshipEnum",
+            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
             "@value": "Contained_Within"
         },
         "uco-core:isDirectional": true,

--- a/examples/owl_trafficking/index.html
+++ b/examples/owl_trafficking/index.html
@@ -596,10 +596,7 @@ ORDER BY ?lHashMethod
         "uco-core:target": {
             "@id": "kb:email-account-99d72bac-8c21-11e9-8902-0c4de9c21b53"
         },
-        "uco-core:kindOfRelationship": {
-            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-            "@value": "Has_Account"
-        },
+        "uco-core:kindOfRelationship": "Has_Account",
         "uco-core:isDirectional": true
     },
     {
@@ -611,10 +608,7 @@ ORDER BY ?lHashMethod
         "uco-core:target": {
             "@id": "kb:facebook-90652808-7341-40d3-9285-774d865ad3f9"
         },
-        "uco-core:kindOfRelationship": {
-            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-            "@value": "Has_Account"
-        },
+        "uco-core:kindOfRelationship": "Has_Account",
         "uco-core:isDirectional": true
     },
     {
@@ -665,10 +659,7 @@ ORDER BY ?lHashMethod
         "uco-core:target": {
             "@id": "kb:c1d3237a-6d7f-4e96-bbef-6eb4c0a621d1"
         },
-        "uco-core:kindOfRelationship": {
-            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-            "@value": "Associated_Account"
-        },
+        "uco-core:kindOfRelationship": "Associated_Account",
         "uco-core:isDirectional": true
     },
     {

--- a/examples/owl_trafficking/owl_trafficking.json
+++ b/examples/owl_trafficking/owl_trafficking.json
@@ -344,10 +344,7 @@
             "uco-core:target": {
                 "@id": "kb:email-account-99d72bac-8c21-11e9-8902-0c4de9c21b53"
             },
-            "uco-core:kindOfRelationship": {
-                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-                "@value": "Has_Account"
-            },
+            "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
@@ -359,10 +356,7 @@
             "uco-core:target": {
                 "@id": "kb:facebook-90652808-7341-40d3-9285-774d865ad3f9"
             },
-            "uco-core:kindOfRelationship": {
-                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-                "@value": "Has_Account"
-            },
+            "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
@@ -413,10 +407,7 @@
             "uco-core:target": {
                 "@id": "kb:c1d3237a-6d7f-4e96-bbef-6eb4c0a621d1"
             },
-            "uco-core:kindOfRelationship": {
-                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-                "@value": "Associated_Account"
-            },
+            "uco-core:kindOfRelationship": "Associated_Account",
             "uco-core:isDirectional": true
         },
         {

--- a/examples/owl_trafficking/owl_trafficking_6.json
+++ b/examples/owl_trafficking/owl_trafficking_6.json
@@ -19,10 +19,7 @@
         "uco-core:target": {
             "@id": "kb:email-account-99d72bac-8c21-11e9-8902-0c4de9c21b53"
         },
-        "uco-core:kindOfRelationship": {
-            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-            "@value": "Has_Account"
-        },
+        "uco-core:kindOfRelationship": "Has_Account",
         "uco-core:isDirectional": true
     },
     {
@@ -34,10 +31,7 @@
         "uco-core:target": {
             "@id": "kb:facebook-90652808-7341-40d3-9285-774d865ad3f9"
         },
-        "uco-core:kindOfRelationship": {
-            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-            "@value": "Has_Account"
-        },
+        "uco-core:kindOfRelationship": "Has_Account",
         "uco-core:isDirectional": true
     },
     {
@@ -88,10 +82,7 @@
         "uco-core:target": {
             "@id": "kb:c1d3237a-6d7f-4e96-bbef-6eb4c0a621d1"
         },
-        "uco-core:kindOfRelationship": {
-            "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
-            "@value": "Associated_Account"
-        },
+        "uco-core:kindOfRelationship": "Associated_Account",
         "uco-core:isDirectional": true
     },
     {

--- a/examples/urgent_evidence/urgent_evidence.json
+++ b/examples/urgent_evidence/urgent_evidence.json
@@ -10,6 +10,7 @@
         "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
         "uco-tool": "https://unifiedcyberontology.org/ontology/uco/tool#",
         "uco-types": "https://unifiedcyberontology.org/ontology/uco/types#",
+        "uco-vocabulary": "https://unifiedcyberontology.org/ontology/uco/vocabulary#",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
@@ -331,7 +332,7 @@
                 "@id": "kb:dvd-uuid-1"
             },
             "uco-core:kindOfRelationship": {
-                "@type": "uco-observable:ObservableObjectRelationshipEnum",
+                "@type": "uco-vocabulary:ObservableObjectRelationshipVocab",
                 "@value": "Contained_Within"
             },
             "uco-core:isDirectional": true,


### PR DESCRIPTION
This patch aligns literals with those defined in UCO's vocabulary
namespace.

Literals declared to be in the namespace, but that are not in the
namespace, have had their types changed to xsd:string.

These literals were identified with the OC-56 branch's updates from
today on the CASE-Examples-QC repository.  These updates reduce the
undefined relationship literals to only instances of xsd:string that are
not in UCO's vocabulary.

References:
* [AC-164] Assess current usage of kindOfRelationship literals
* [CASE-Examples-QC] https://github.com/ajnelson-nist/CASE-Examples-QC/
* [UCO OC-56] (CP-49) UCO needs to document the core:Relationship object
  and why it is used instead of RDF predicates

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>