### PR TITLE
Fix HTML typo

### DIFF
--- a/resources/instance_data.html
+++ b/resources/instance_data.html
@@ -62,7 +62,7 @@ RDF is a flexible language, providing many ways to represent the same data.  Exa
 
 <h3>Hash vs. slash</h3>
 
-<p>Namespace prefixes in RDF typically end in with the <q>Hash or slash?</q> decision: Should the identifier end with a <code>#</code> character to represent an HTML within-page anchor point, or with a / character to represent an independent page at the end of an IRI?</p>
+<p>Namespace prefixes in RDF typically end in with the <q>Hash or slash?</q> decision: Should the identifier end with a <code>#</code> character to represent an HTML within-page anchor point, or with a <code>/</code> character to represent an independent page at the end of an IRI?</p>
 
 <p>CASE examples end their knowledge base prefix with a slash character, based on the assumption that a knowledge base navigator might be supporting multiple elementary types of clients: Graph engines, which might make programmatic requests of the IRI; and web browsers, for users wanting to view HTTP renders of the IRI.  IRIs that end in hash might cause an expectation that a knowledge base provide a <q>dump</q> of all node identifiers to a web browser, and rely on the browser to skip into the middle of the page.</p>
 


### PR DESCRIPTION
References:
* [AC-134] Document IRI usage of hash vs. slash

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>