### PR TITLE
Add redirect from prior gallery URL

### DIFF
--- a/ontology/gallery.html
+++ b/ontology/gallery.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirection to /examples/</title>
+    <link rel="canonical" href="/examples/"/>
+    <meta name="robots" content="noindex" />
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/examples/" />
+  </head>
+</html>


### PR DESCRIPTION
One oversight from implementation of ONT-354 was that there were at
least two external locations that linked to the examples gallery at its
prior location, one of which will not be an immediate correction.  While
those external links are being corrected, we should have a redirect in
place.

This page can be deleted after some period where we believe the
corrected links have had a chance to propagate.

A few implementation answers were found while searching for syntax
reference.

References:
* https://stackoverflow.com/a/19717455
* https://oktomus.com/posts/2019/github-pages-redirect-any-link/
* [ONT-354] The examples on the website need a unified index and layout
  revision
* [ONT-442] (CP-37) The ontology repository's README includes a broken
  link to the website examples gallery

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>