### PR TITLE
Use Python venv to build virtual environment for CI

### DIFF
--- a/.github/workflows/web_resources.yml
+++ b/.github/workflows/web_resources.yml
@@ -33,10 +33,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Python virtualenv for Github runner
-      run: |
-        python -m pip install --upgrade pip
-        pip install virtualenv
     - name: Clear generated files
       run: make clean
     - name: Regenerate files

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ all: \
   .git_submodule_init.done.log \
   requirements.txt
 	rm -rf venv
-	$(PYTHON3) -m virtualenv \
-	  --python=$(PYTHON3) \
+	$(PYTHON3) -m venv \
 	  venv
 	source venv/bin/activate \
 	  && pip install \


### PR DESCRIPTION
References:
* [AC-195] Use Python venv instead of virtualenv to build virtual
  environments for CI

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>