### PR TITLE
Ignore __pycache__ from urgent_evidence example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 .git_submodule_init.done.log
 .venv.done.log
 venv
+examples/urgent_evidence/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ _site
 .git_submodule_init.done.log
 .venv.done.log
 venv
-examples/urgent_evidence/__pycache__
+__pycache__
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site
 .venv.done.log
 venv
 examples/urgent_evidence/__pycache__
+*.swp


### PR DESCRIPTION
This QOL PR will adjust the gitignore file to ignore the __pycache__ folder in examples/urgent_evidence.