### PR TITLE
Include wheel in venv build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ all: \
 	  && pip install \
 	    --upgrade \
 	    pip \
-	    setuptools
+	    setuptools \
+	    wheel
 	source venv/bin/activate \
 	  && pip install \
 	    dependencies/CASE-Utilities-Python


### PR DESCRIPTION
This silences the notices that the "legacy setup.py" is used when `pip`
installs from local directories.

References:
* [AC-195] Use Python venv instead of virtualenv to build virtual
  environments for CI

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>