### PR TITLE
Update clean steps to remove built -develop and -unstable ontology bu…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,14 +93,20 @@ check-migration-0.2.0:
 	  check
 
 clean:
-	@rm -f \
-	  .git_submodule_init.done.log \
-	  .venv.done.log
-	@rm -rf \
-	  venv
 	@$(MAKE) \
 	  --directory examples \
 	  clean
+	@rm -f \
+	  .dependencies.done.log
+	@$(MAKE) \
+	  --directory dependencies \
+	  clean
+	@rm -f \
+	  .venv.done.log
+	@rm -rf \
+	  venv
+	@rm -f \
+	  .git_submodule_init.done.log
 	@$(MAKE) \
 	  --directory releases/0.2.0/migration \
 	  clean

--- a/dependencies/Makefile
+++ b/dependencies/Makefile
@@ -48,3 +48,8 @@ CASE-unstable.ttl: \
 	    _$@ \
 	    $(case_unstable_ttls)
 	mv _$@ $@
+
+clean:
+	@rm -f \
+	  CASE-develop.ttl \
+	  CASE-unstable.ttl

--- a/examples/src/example-src.mk
+++ b/examples/src/example-src.mk
@@ -162,6 +162,7 @@ check-pytest: \
 clean:
 	@rm -f \
 	  *.sed \
+	  *validation*ttl \
 	  generated-* \
 	  normalized-* \
 	  query-*.md


### PR DESCRIPTION
…ilds

The top-level Makefile now rolls back flag files before cleaning what
each flag file represented finishing, in case of error halting the clean
partway through.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>