### PR TITLE
Confirm Turtle translation ability

### DIFF
--- a/examples/src/example-src.mk
+++ b/examples/src/example-src.mk
@@ -52,7 +52,8 @@ all: \
   check-pytest
 
 .PRECIOUS: \
-  $(example_name)_validation.ttl
+  $(example_name)_validation.ttl \
+  generated-$(example_name).json
 
 $(example_name)_validation.ttl: \
   generated-$(example_name).json \
@@ -126,13 +127,13 @@ check: \
   $(example_name)_validation-develop.ttl \
   $(example_name)_validation-unstable.ttl \
   check-pytest \
-  generated-index.html \
-  generated-$(example_name).json
+  generated-index.html
 
 # Run pytest tests only if any are written.
 # (Pytest exits in an error state if called with no tests found.)
 check-pytest: \
   $(example_name)_validation.ttl \
+  generated-$(example_name).ttl \
   generated-$(example_name)-wasInformedBy.json
 	test 0 -eq $$(/bin/ls *_test.py test_*.py 2>/dev/null | wc -l) \
 	  || ( \
@@ -183,6 +184,16 @@ generated-$(example_name).json: \
 	  __$@ \
 	  _$@
 	rm __$@
+	mv _$@ $@
+
+generated-$(example_name).ttl: \
+  generated-$(example_name).json
+	java -jar $(RDF_TOOLKIT_JAR) \
+	  --inline-blank-nodes \
+	  --source $< \
+	  --source-format json-ld \
+	  --target _$@ \
+	  --target-format turtle
 	mv _$@ $@
 
 # Not all examples will require the chain of communication, but some do.

--- a/examples/urgent_evidence/index.html
+++ b/examples/urgent_evidence/index.html
@@ -423,12 +423,7 @@ WHERE {
         SELECT ?nExhibitDevice
         WHERE {
           ?nExhibitDevice
-            a/rdfs:subClassOf* uco-observable:ObservableObject ;
-            uco-core:hasFacet ?nExhibitDeviceDeviceFacet ;
-            .
-
-          ?nExhibitDeviceDeviceFacet
-            a uco-observable:DeviceFacet ;
+            a/rdfs:subClassOf* uco-observable:Device ;
             .
         }
       }  # Ends sub-query: SELECT ?nExhibitDevice

--- a/examples/urgent_evidence/src/query-exhibit_photos.sparql
+++ b/examples/urgent_evidence/src/query-exhibit_photos.sparql
@@ -71,12 +71,7 @@ WHERE {
         SELECT ?nExhibitDevice
         WHERE {
           ?nExhibitDevice
-            a/rdfs:subClassOf* uco-observable:ObservableObject ;
-            uco-core:hasFacet ?nExhibitDeviceDeviceFacet ;
-            .
-
-          ?nExhibitDeviceDeviceFacet
-            a uco-observable:DeviceFacet ;
+            a/rdfs:subClassOf* uco-observable:Device ;
             .
         }
       }  # Ends sub-query: SELECT ?nExhibitDevice

--- a/examples/urgent_evidence/src/test_urgent_evidence.py
+++ b/examples/urgent_evidence/src/test_urgent_evidence.py
@@ -25,7 +25,7 @@ _logger = logging.getLogger(os.path.basename(__file__))
 NS_SH = rdflib.SH
 
 graph = rdflib.Graph()
-graph.parse("generated-urgent_evidence.json", format="json-ld")
+graph.parse("generated-urgent_evidence.ttl", format="turtle")
 graph.parse("generated-urgent_evidence-wasInformedBy.json", format="json-ld")
 # TODO - Remove CASE-unstable.ttl reference on release of CASE 0.6.0.
 top_srcdir = pathlib.Path(os.path.dirname(__file__)).parent.parent.parent

--- a/examples/urgent_evidence/src/urgent_evidence_base.json
+++ b/examples/urgent_evidence/src/urgent_evidence_base.json
@@ -1461,12 +1461,7 @@
         },
         {
             "@id": "kb:subject-device-uuid-1",
-            "@type": "uco-observable:Device",
-            "uco-core:hasFacet": [
-                {
-                    "@type": "uco-observable:DeviceFacet"
-                }
-            ]
+            "@type": "uco-observable:Device"
         }
     ]
 }

--- a/examples/urgent_evidence/urgent_evidence.json
+++ b/examples/urgent_evidence/urgent_evidence.json
@@ -1461,12 +1461,7 @@
         },
         {
             "@id": "kb:subject-device-uuid-1",
-            "@type": "uco-observable:Device",
-            "uco-core:hasFacet": [
-                {
-                    "@type": "uco-observable:DeviceFacet"
-                }
-            ]
+            "@type": "uco-observable:Device"
         }
     ]
 }


### PR DESCRIPTION
The CASE-Examples-QC repository includes a step that converts example
JSON-LD to Turtle.  This had not yet been run when testing the upgrade
of rdf-toolkit to the post-1.10 state.  Not having done so, we missed
that there is a potential build-halting issue with `rdf-toolkit`.

The current version of `rdf-toolkit` contains a behavior (possibly a
bug) that dislikes this snippet of JSON-LD:

```json
{
    "@id": "urn:example:kb:object-1",
    "@type": "owl:Thing",
    "uco-core:hasFacet": {
        "@type": "uco-core:Facet"
    }
}
```

The blank node that contains only a type assertion raises a
`NullPointerException` in a step related to determining sort order of
blank nodes.

A follow-on patch will remove one occurrence of this behavior, as it
turns out to be unhelpful data (an empty `DeviceFacet`).  Before the
`ObservableObject` subclass hierarchy was populated, that empty `Facet`
was needed for duck-typing.  With `ObservableObject` subclasses in
place, it is no longer necessary.

This problem will need to be addressed upstream.

The first patch revises the testing workflow to include a step converting
the glommed JSON-LD to Turtle for `pytest` review.