### PR TITLE
Add Ontology Documentation to Menu

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -17,6 +17,8 @@
     #   link: /ontology/guides.html
     - name: Versioning
       link: /ontology/versioning.html
+    - name: Documentation
+      link: https://ontology.caseontology.org/
     - name: SPACE
     - header: Examples
     - name: Gallery


### PR DESCRIPTION
Add the documentation (https://ontology.caseontology.org/case/documentation/index.html) to the Ontology menu of the CASE website.