### PR TITLE
Bump 0.7.0 Release References

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -3,12 +3,12 @@
 - name: Releases
   submenuitems:
     - name: Latest Release
-      link: /releases/0.6.0/
+      link: /releases/0.7.0/
     - name: Archived Releases
       link: /releases/archive/
     - name: SPACE
     - name: Under Development
-      link: /releases/0.7.0/
+      link: /releases/0.8.0/
 - name: Ontology
   submenuitems:
     - name: Introduction

--- a/_data/releases/releases.yml
+++ b/_data/releases/releases.yml
@@ -19,3 +19,6 @@
 - title: 0.6.0
   date: 2022-03-24
   desc: Adoption of UCO 0.8.0. Alignment of exhibit number and root exhibit number definitions.
+- title: 0.7.0
+  date: 2022-06-17
+  desc: Adoption of UCO 0.9.0. Updates to workflow technology transitions and depedency upgrades.

--- a/releases/0.8.0/index.md
+++ b/releases/0.8.0/index.md
@@ -1,0 +1,9 @@
+---
+title: 0.8.0 Release
+layout: releases
+custom_css: releases
+---
+
+# {{ page.title }}
+
+*Date: TBD*


### PR DESCRIPTION
- Add 0.8.0 placeholder page
- Add 0.7.0 release to releases list
- Point "Current Release" to 0.7.0