### PR TITLE
Correct class reference

### DIFF
--- a/examples/asgard/asgard.json
+++ b/examples/asgard/asgard.json
@@ -491,7 +491,7 @@
         },
         {
             "@id": "kb:investigator-899bb310-f5cd-4ab5-9e96-1234a37ed1da",
-            "@type": "uco-identity:Role"
+            "@type": "case-investigation:Investigator"
         },
         {
             "@id": "kb:application1-8538c226-1ba5-473b-8342-96150a4ab4ed",

--- a/examples/asgard/src/asgard-supplements.json
+++ b/examples/asgard/src/asgard-supplements.json
@@ -25,7 +25,7 @@
     },
     {
         "@id": "kb:investigator-899bb310-f5cd-4ab5-9e96-1234a37ed1da",
-        "@type": "uco-identity:Role"
+        "@type": "case-investigation:Investigator"
     },
     {
         "@id": "kb:application1-8538c226-1ba5-473b-8342-96150a4ab4ed",


### PR DESCRIPTION
`uco-identity:Role` does not exist.  `uco-role:Role` does, but CASE has a more specific subclass that would be more appropriate to use here.

This PR is only a correction of a class reference.  Further discussion needs to be had on whether `role:Role` is appropriate to use as an object of the `action:performer` property.  I believe this usage is incongruous with other ontologies outside of UCO.