### PR TITLE
Remove redundant example rebuilds

### DIFF
--- a/examples/asgard/src/asgard_json.py
+++ b/examples/asgard/src/asgard_json.py
@@ -17,7 +17,7 @@ into a single JSON-LD file.  This script is likely to be replaced with
 an alternative mechanism.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import json
 import sys
@@ -36,6 +36,7 @@ def main() -> None:
                     obj["uco-core:object"].append(item)
 
     json.dump(obj, sys.stdout, indent=4)
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":

--- a/examples/crossover_heist/src/crossover_heist_json.py
+++ b/examples/crossover_heist/src/crossover_heist_json.py
@@ -15,7 +15,7 @@
 This script was copied from the Owl Trafficking scenario.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import logging
 import json
@@ -42,6 +42,7 @@ def main() -> None:
                 obj["@graph"].append(item)
 
     json.dump(obj, sys.stdout, indent=4)
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":

--- a/examples/crossover_wmd/src/crossover_wmd_json.py
+++ b/examples/crossover_wmd/src/crossover_wmd_json.py
@@ -17,7 +17,7 @@ into a single JSON-LD file.  This script is likely to be replaced with
 an alternative mechanism.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import logging
 import json
@@ -48,6 +48,7 @@ def main() -> None:
                 obj["@graph"].append(item)
 
     json.dump(obj, sys.stdout, indent=4)
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":

--- a/examples/hardware_duplicator/src/hardware_duplicator_json.py
+++ b/examples/hardware_duplicator/src/hardware_duplicator_json.py
@@ -15,7 +15,7 @@
 This script was copied from the Owl Trafficking scenario.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import logging
 import json
@@ -42,6 +42,7 @@ def main() -> None:
                 obj["@graph"].append(item)
 
     json.dump(obj, sys.stdout, indent=4)
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":

--- a/examples/owl_trafficking/src/owl_trafficking_json.py
+++ b/examples/owl_trafficking/src/owl_trafficking_json.py
@@ -17,7 +17,7 @@ into a single JSON-LD file.  This script is likely to be replaced with
 an alternative mechanism.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import logging
 import json
@@ -44,6 +44,7 @@ def main() -> None:
                 obj["@graph"].append(item)
 
     json.dump(obj, sys.stdout, indent=4)
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":

--- a/examples/src/example-basedir.mk
+++ b/examples/src/example-basedir.mk
@@ -62,8 +62,18 @@ all:
 	          > $$TMPDIR/$(example_name).json \
 	          && echo "INFO:examples/$(example_name):Edits found in $(example_name).json, and about to be overwritten.  Stashing state in temporary file in case they were not meant to be overwritten.  Restore by running: 'mv $$TMPDIR/$(example_name).json $(example_name).json'." >&2 \
 	    )
-	cp src/generated-index.html index.html
-	cp src/generated-$(example_name).json $(example_name).json
+	diff \
+	  index.html \
+	  src/generated-index.html \
+	  || cp \
+	    src/generated-index.html \
+	    index.html
+	diff \
+	  $(example_name).json \
+	  src/generated-$(example_name).json \
+	  || cp \
+	    src/generated-$(example_name).json \
+	    $(example_name).json
 
 # Generic tests:
 # * Confirm the Git-committed version of the combined example JSON matches the file generated from the JSON pieces.

--- a/examples/src/example-src.mk
+++ b/examples/src/example-src.mk
@@ -96,12 +96,7 @@ generated-$(example_name).json: \
 	python3 $(example_name)_json.py \
 	  $(example_name)_base.json \
 	  $(example_snippets_json) \
-	  > __$@
-	@#Use same normalization procedure when constructing generated file.
-	python3 -m json.tool \
-	  __$@ \
-	  _$@
-	rm __$@
+	  > _$@
 	mv _$@ $@
 
 generated-$(example_name).ttl: \


### PR DESCRIPTION
The commit messages document this PR's purpose.  This is an aid to offline development.

As a matter of Make orchestration programming, I will handle merging this myself once CI passes. I've been exercising this by deleting various files and running and re-running `make` or `make check`, and I'm satisfied with the rebuild steps.