### PR TITLE
Bump Dockerfile to use Ruby 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.1-bullseye
+FROM --platform=linux/amd64 ruby:3.3-bullseye
 
 # Define the working directory
 WORKDIR /usr/app/src


### PR DESCRIPTION
The `jekyll-build-pages` GitHub Action today uses Ruby 3.3, and has since 2024-08-06.

References:
* https://github.com/actions/jekyll-build-pages/blob/b55ba671954459b92b0cd26dacd80f7deaedecaa/Dockerfile#L1