### PR TITLE
Refresh Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.0.0)
+    activesupport (7.1.5)
       base64
       benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
       securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
+      tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
@@ -45,7 +45,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     ffi (1.17.0)
-    ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -229,17 +228,14 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.1)
     mercenary (0.3.6)
-    mini_portile2 (2.8.8)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.25.1)
+    mutex_m (0.2.0)
     net-http (0.5.0)
       uri
-    nokogiri (1.16.7)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -277,7 +273,6 @@ GEM
     webrick (1.9.0)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Commands run, in a local Ubuntu 22.04 instance:

```bash
bundle config set --local path 'vendor/bundle'
bundle install
```

These updates seem satisfiable, per:

```bash
bundle check --dry-run --gemfile Gemfile
```

That `check` command was failing prior to this patch.

References:
* https://github.com/actions/jekyll-build-pages/blob/e9ec94b518184f806907923eaeb6bc69294b0bce/entrypoint.sh#L15