### PR TITLE
Fix timestamp typo

### DIFF
--- a/examples/crossover_wmd/crossover_wmd.json
+++ b/examples/crossover_wmd/crossover_wmd.json
@@ -700,7 +700,7 @@
                     "@type": "uco-observable:FileFacet",
                     "uco-observable:observableCreatedTime": {
                         "@type": "xsd:dateTime",
-                        "@value": "2020-05-16T10:12.40Z"
+                        "@value": "2020-05-16T10:12:40Z"
                     },
                     "uco-observable:extension": "xml",
                     "uco-observable:fileName": "19_UFED_ANDROID_CROSSOVER.xml",

--- a/examples/crossover_wmd/index.html
+++ b/examples/crossover_wmd/index.html
@@ -204,7 +204,7 @@ jumbo_desc: Cellebrite XML Report Example
                 "@type": "uco-observable:FileFacet",
                 "uco-observable:observableCreatedTime": {
                     "@type": "xsd:dateTime",
-                    "@value": "2020-05-16T10:12.40Z"
+                    "@value": "2020-05-16T10:12:40Z"
                 },
                 "uco-observable:extension": "xml",
                 "uco-observable:fileName": "19_UFED_ANDROID_CROSSOVER.xml",

--- a/examples/crossover_wmd/src/crossover_wmd-report_generation.json
+++ b/examples/crossover_wmd/src/crossover_wmd-report_generation.json
@@ -71,7 +71,7 @@
                 "@type": "uco-observable:FileFacet",
                 "uco-observable:observableCreatedTime": {
                     "@type": "xsd:dateTime",
-                    "@value": "2020-05-16T10:12.40Z"
+                    "@value": "2020-05-16T10:12:40Z"
                 },
                 "uco-observable:extension": "xml",
                 "uco-observable:fileName": "19_UFED_ANDROID_CROSSOVER.xml",


### PR DESCRIPTION
A recent RDFLib parser update changed the parsed value of the modified timestamp as follows:

```patch
-       uco-observable:observableCreatedTime "2020-05-16T10:12:24+00:00"^^xsd:dateTime ;
+       uco-observable:observableCreatedTime "2020-05-16T10:12:00.400000+00:00"^^xsd:dateTime ;
```